### PR TITLE
Updating gitignore for more robust coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,39 @@
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
+_site/
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+
 # OS generated files #
 ######################
 .DS_Store
 .DS_Store?
 .Spotlight-V100
 .Trashes
+Icon?
 ehthumbs.db
 Thumbs.db
 
@@ -17,6 +47,7 @@ Thumbs.db
 *.egg-info/
 __pycache__/
 *.py[cod]
+.env
 
 # Django #
 #################
@@ -37,3 +68,5 @@ coverage.xml
 node_modules/
 bower_components/
 .grunt/
+src/vendor/
+dist/


### PR DESCRIPTION
Updating gitignore for more robust coverage
 
## Additions
 
- Added new Compiled Source group of filetypes
- Added new Package group of filetypes
- Added new Logs and databases group of filetypes
 
## Removals
 
None
 
## Changes
 
- Added `.env` files to Python group
- Added `src/vendor/` dir to Front End group
- Added `/dist` dir to Front End group
 
## Testing
 
None

## Review
 
- @Scotchester 
- @ascott1 
- @contolini 
- @marcesher 
et al
 
## Preview

None
 
## Notes
 
- All of these filetypes come from the existing cfgov-refresh project and experience updating that project with the CF generator