### PR TITLE
Specify merge driver for changelog to avoid text conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/CHANGELOG.md merge=union


### PR DESCRIPTION
Per [this tip](http://krlmlr.github.io/using-gitattributes-to-avoid-merge-conflicts/) it's possible to auto-merge conflicts for files where the order of lines doesn't matter (such as changelogs and other non-code files).

This PR adds a `.gitattributes` file that will help projects avoid changelog conflicts.