### PR TITLE
Install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 #### CFPB Open Source Project Template Instructions
 
 1. Create a new project.
-2. Copy these files into the new project.
+2. [Copy these files into the new project](#installation)
 3. Update the README, replacing the contents below as prescribed.
 4. Add any libraries, assets, or hard dependencies whose source code will be included
    in the project's repository to the _Exceptions_ section in the [TERMS](TERMS.md).
@@ -11,6 +11,14 @@
 7. Write some great software and tell people about it.
 
 > Keep the README fresh! It's the first thing people see and will make the initial impression.
+
+## Installation
+
+To install all of the template files, run the following script from the root of your project's directory:
+
+```
+bash -c "$(curl -s https://raw.githubusercontent.com/CFOB/open-source-project-template/master/install.sh)"
+```
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 To install all of the template files, run the following script from the root of your project's directory:
 
 ```
-bash -c "$(curl -s https://raw.githubusercontent.com/CFOB/open-source-project-template/master/install.sh)"
+bash -c "$(curl -s https://raw.githubusercontent.com/CFPB/open-source-project-template/master/install.sh)"
 ```
 
 ----

--- a/install.sh
+++ b/install.sh
@@ -27,12 +27,16 @@ echo "downloading files"
 for file in "${root_files[@]}"; do
   if [ ! -f "./${file}" ]; then
     curl -so "./${file}" "${url}/${file}"
+  else
+    echo "${file} already exists, skipping"
   fi
 done
 
 for file in "${gh_files[@]}"; do
   if [ ! -f "./${file}" ]; then
     curl -so ".github/${file}" "${url}/.github/${file}"
+  else
+    echo ".github/${file} already exists, skipping"
   fi
 done
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+url="https://raw.githubusercontent.com/CFPB/open-source-project-template/master"
+
+root_files=(
+  ".gitattributes"
+  ".gitignore"
+  "CHANGELOG.md"
+  "CONTRIBUTING.md"
+  "INSTALL.md"
+  "LICENSE"
+  "README.md"
+  "TERMS.md"
+)
+
+gh_files=(
+  "ISSUE_TEMPLATE.md"
+  "PULL_REQUEST_TEMPLATE.md"
+)
+
+echo "creating .github directory"
+
+mkdir -p .github
+
+echo "downloading files"
+
+for file in "${root_files[@]}"; do
+  if [ ! -f "./${file}" ]; then
+    curl -so "./${file}" "${url}/${file}"
+  fi
+done
+
+for file in "${gh_files[@]}"; do
+  if [ ! -f "./${file}" ]; then
+    curl -so ".github/${file}" "${url}/.github/${file}"
+  fi
+done
+
+echo "download complete"


### PR DESCRIPTION
I found myself wanting to add the files from this directory to a project, but didn't want to do a manual copy and paste. This adds a bash script for easy installation of all of the files in this repo.

## Additions

- `install.sh` file

## Removals

- n/a

## Changes

- Updates the README with instructions for using the script

## Testing

To test that this works, run the following command from an empty directory:

```
bash -c "$(curl -s https://raw.githubusercontent.com/ascott1/open-source-project-template/install-script/install.sh)"
```

## Review

- @marcesher
- @Scotchester 
- @willbarton 

[Preview this PR without the whitespace changes](?w=0)