### PR TITLE
Ignore pyenv's `.python-version` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,10 @@ __pycache__/
 *.py[cod]
 .env
 
+# pyenv #
+#########
+.python-version
+
 # Django #
 #################
 *.egg-info


### PR DESCRIPTION
This will allow developers using pyenv to add a .python-version file
to specify different python versions to test against.
