### PR TITLE
Ignore .python-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ Thumbs.db
 __pycache__/
 *.py[cod]
 .env
+.python-version
 
 # pyenv #
 #########


### PR DESCRIPTION
This PR adds .python-version to our template .gitignore. 